### PR TITLE
Allow to save arbitrary information into eclosor.npz

### DIFF
--- a/eclosor/gmf/__init__.py
+++ b/eclosor/gmf/__init__.py
@@ -77,7 +77,7 @@ class GMFRecommender:
         self._update_dicts()
         self.model = GMFTModel(user_common_features, item_common_features, item_coordinates, item_temporal_features,
                                dropout_p, embedding_dim, hidden_layer_dim, time_emb_dim)
-    def save_model(self, data_directory, **args):
+    def save_model(self, data_directory, filename='embed.npz', **args):
         self.model.eval()
         with torch.no_grad():
             self.params = dict(
@@ -91,10 +91,10 @@ class GMFRecommender:
                 distance_bias = self.model.distance_filter[0].bias.cpu().detach().numpy()[0]
             )
             self.params.update(args)
-            pickle.dump(self.params, open(os.path.join(data_directory, 'embed.npz'), 'wb'))
+            pickle.dump(self.params, open(os.path.join(data_directory, filename), 'wb'))
 
-    def load_model(self, data_directory):
-        self.params = pickle.load(open(os.path.join(data_directory, 'embed.npz'), 'rb'))
+    def load_model(self, data_directory, filename='embed.npz'):
+        self.params = pickle.load(open(os.path.join(data_directory, filename), 'rb'))
         self.items = self.params['items']
         self.users = self.params['users']
         self._update_dicts()

--- a/eclosor/gmf/__init__.py
+++ b/eclosor/gmf/__init__.py
@@ -77,7 +77,7 @@ class GMFRecommender:
         self._update_dicts()
         self.model = GMFTModel(user_common_features, item_common_features, item_coordinates, item_temporal_features,
                                dropout_p, embedding_dim, hidden_layer_dim, time_emb_dim)
-    def save_model(self, data_directory):
+    def save_model(self, data_directory, **args):
         self.model.eval()
         with torch.no_grad():
             self.params = dict(
@@ -90,6 +90,7 @@ class GMFRecommender:
                 distance_weight = self.model.distance_filter[0].weight.cpu().detach().numpy()[0],
                 distance_bias = self.model.distance_filter[0].bias.cpu().detach().numpy()[0]
             )
+            self.params.update(args)
             pickle.dump(self.params, open(os.path.join(data_directory, 'embed.npz'), 'wb'))
 
     def load_model(self, data_directory):


### PR DESCRIPTION
We need this in order to save the meta information about
the machine-learned model.

I'm planning to use this capability to save "objective"
information (i.e. whether the paritcular model is optimized
for SERENDIPITY or PRECISION).

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>