### PR TITLE
メタデータをembed.npzに保存できるようにする

### DIFF
--- a/eclosor/gmf/__init__.py
+++ b/eclosor/gmf/__init__.py
@@ -77,7 +77,7 @@ class GMFRecommender:
         self._update_dicts()
         self.model = GMFTModel(user_common_features, item_common_features, item_coordinates, item_temporal_features,
                                dropout_p, embedding_dim, hidden_layer_dim, time_emb_dim)
-    def save_model(self, data_directory):
+    def save_model(self, data_directory, **args):
         self.model.eval()
         with torch.no_grad():
             self.params = dict(
@@ -90,6 +90,7 @@ class GMFRecommender:
                 distance_weight = self.model.distance_filter[0].weight.cpu().detach().numpy()[0],
                 distance_bias = self.model.distance_filter[0].bias.cpu().detach().numpy()[0]
             )
+            self.params.update(args)
             pickle.dump(self.params, open(os.path.join(data_directory, 'embed.npz'), 'wb'))
 
     def load_model(self, data_directory):


### PR DESCRIPTION
Eclosorのモデルにメタデータを保存できるようにするパッチです。

次のように、`save_model()`の呼び出し時の引数で任意のキーと
値のペアを渡すことが可能です。

```python3
recommender.save_model("/var/data", foo="bar")
```

モデルに学習時のメタデータを保持するのに利用する予定です。
